### PR TITLE
Use cc65 __fastcall__ calling convention (compiler default).

### DIFF
--- a/ports/6502/arch_a.s
+++ b/ports/6502/arch_a.s
@@ -138,9 +138,6 @@ _savedchars:
 ; ---------------------------------------------------------------
 
 .proc  _p_putchar
-    ldy     #$00
-    lda     (sp),y
-
     cmp     #13
     bne     putc0
     ldx     _savedchars
@@ -184,7 +181,7 @@ putc5:
     jsr     SCREEN_OUT
 putc2:
     lda     #1
-    jmp     incsp1
+    rts
 
 .endproc
 
@@ -740,7 +737,6 @@ tmi02:
     lda     KEY_BUF
     ldx     KEY_BUF+1
     stx     KEY_BUF
-    jsr     pusha
     jsr     _c_nos_keyinput
 tmi05:
 .ENDIF
@@ -845,10 +841,8 @@ orgisr:
 ; ---------------------------------------------------------------
 
 .proc _p_pos_findbit
-    ldy     #$00
-    lda     (sp),y
     tax
-    iny
+    ldy     #$00
     lda     (sp),y
     ;accu = bitfield
     ;x = offset
@@ -876,11 +870,11 @@ bitFound:
     bcs     correctOffset
 
     ; return a
-    jmp     incsp2
+    jmp     incsp1
          
 correctOffset:  
     sbc     #9
     ; return a
-    jmp     incsp2
+    jmp     incsp1
 
 .endproc

--- a/ports/6502/arch_c.c
+++ b/ports/6502/arch_c.c
@@ -307,11 +307,8 @@ VAR_t p_pos_initTask(POSTASK_t task,
   /* allocate call- and data-stack memory */
   alloc_stacks(task);
 
-  /* initialize data stack */
-  sp = task->dstackptr - 2;
-  task->dstackptr = sp;
-  sp[1] = (UVAR_t)(((MEMPTR_t)funcarg) >> 8);
-  sp[0] = (UVAR_t)((MEMPTR_t)funcarg);
+  /* cc65 defaults to __fastcall__, so data stack is empty as
+     funcarg is passed in ax */
 
   /* initialize call stack */
 
@@ -341,8 +338,8 @@ VAR_t p_pos_initTask(POSTASK_t task,
   sp[4] = (UVAR_t)((MEMPTR_t)((void*)funcptr));
 
   sp[3] = 0x00;  /* flags. irqs enabled. */
-  sp[2] = 0x00;  /* A */
-  sp[1] = 0x00;  /* X */
+  sp[2] = (UVAR_t)((MEMPTR_t)funcarg);  /* A */
+  sp[1] = (UVAR_t)(((MEMPTR_t)funcarg) >> 8);  /* X */
   sp[0] = 0x02;  /* Y */
 
   return 0;

--- a/ports/6502/arch_c.c
+++ b/ports/6502/arch_c.c
@@ -278,7 +278,7 @@ static void free_stacks(POSTASK_t task)
  * INITIALIZE THIS PORT
  *-------------------------------------------------------------------------*/
 
-void p_pos_initArch(void)
+void POSCALL p_pos_initArch(void)
 {
 #if (STASKS != 0)
   unsigned char *p = (unsigned char*) stasks_alloctab_g;
@@ -299,16 +299,22 @@ void p_pos_initArch(void)
 #error Only  POSCFG_TASKSTACKTYPE = 2  supported
 #endif
 
-VAR_t p_pos_initTask(POSTASK_t task,
-                    POSTASKFUNC_t funcptr, void *funcarg)
+VAR_t POSCALL p_pos_initTask(POSTASK_t task,
+                             POSTASKFUNC_t funcptr, void *funcarg)
 {
   UVAR_t *sp;
 
   /* allocate call- and data-stack memory */
   alloc_stacks(task);
 
-  /* cc65 defaults to __fastcall__, so data stack is empty as
-     funcarg is passed in ax */
+#if __CC65__ < 0x02F0
+  /* initialize data stack for older compiler, which
+     doesn't default to __fastcall__ */
+  sp = task->dstackptr - 2;
+  task->dstackptr = sp;
+  sp[1] = (UVAR_t)(((MEMPTR_t)funcarg) >> 8);
+  sp[0] = (UVAR_t)((MEMPTR_t)funcarg);
+#endif
 
   /* initialize call stack */
 
@@ -346,7 +352,7 @@ VAR_t p_pos_initTask(POSTASK_t task,
 }
 
 
-void  p_pos_freeStack(POSTASK_t task)
+void POSCALL p_pos_freeStack(POSTASK_t task)
 {
   free_stacks(task);
 }

--- a/ports/6502/port.h
+++ b/ports/6502/port.h
@@ -53,6 +53,8 @@
 /* The cc65 compiler does not support the 'volatile' -keyword correctly */
 #define volatile
 
+/* New compiler defaults to __fastcall__ but old one doesn't. */
+#define POSCALL __fastcall__
 
 
 /*---------------------------------------------------------------------------

--- a/ports/6502/port.mak
+++ b/ports/6502/port.mak
@@ -93,7 +93,7 @@ else
 endif
 
 # Define Compiler Flags
-CFLAGS += --all-cdecl -t $(TG) -O -T -o 
+CFLAGS += -t $(TG) -O -T -o 
 
 # Define Assembler Flags
 ASFLAGS += -t $(TG) -o 


### PR DESCRIPTION
cc65 compiler defaults to fastcall calling convention nowadays. Change assembly stuff so that it is compatible with it. After this works OK, workaround done for #1 is no longer necessary.