### PR TITLE
Fix typo mistakes in some make-files.

### DIFF
--- a/examples/make/library.mak
+++ b/examples/make/library.mak
@@ -55,7 +55,7 @@ DIR_USRINC +=
 # set this variable, the files will be stored in the pico]OS root
 # root directory structure (pioos/out, picoos/lib, picoos/obj)
 # Note: Please keep the ifeq/endif pair. This allows to set the
-# output directory from outsite (may be by a project makefile).
+# output directory from outside (maybe by a project makefile).
 ifeq '$(strip $(DIR_OUTPUT))' ''
 DIR_OUTPUT = $(CURRENTDIR)/bin
 endif

--- a/examples/make/outfile.mak
+++ b/examples/make/outfile.mak
@@ -77,7 +77,7 @@ DIR_OUTPUT = $(CURRENTDIR)/bin
 # Include pico]OS based modules. Set here the list of modules
 # (libraries) you want to use in your project. Note that the module
 # name is the name of the directory where the sources and the makefile
-# is stored. The makefile must be named "makefile" or "makefile.pico"
+# are stored. The makefile must be named "makefile" or "makefile.pico"
 # Example:  MODULES += $(RELROOT)../lcdinterface
 MODULES +=
 

--- a/make/compile.mak
+++ b/make/compile.mak
@@ -34,7 +34,7 @@
 # Compile files
 
 ifeq '$(strip $(MAKE_CPL))' ''
-($error common.mak not included)
+$(error common.mak not included)
 endif
 
 # Ensure the port variable is set.

--- a/make/lib.mak
+++ b/make/lib.mak
@@ -34,7 +34,7 @@
 # Build target: generate library
 
 ifeq '$(strip $(MAKE_LIB))' ''
-($error common.mak not included)
+$(error common.mak not included)
 endif
 
 ifneq '$(strip $(OLIBNAME))' ''
@@ -42,7 +42,7 @@ TARGET := $(OLIBNAME)
 endif
 
 ifeq '$(strip $(TARGET))' ''
-($error TARGET library name not set)
+$(error TARGET library name not set)
 endif
 
 # ---------------------------------------------------------------------------

--- a/make/out.mak
+++ b/make/out.mak
@@ -34,11 +34,11 @@
 # Build target: generate executable
 
 ifeq '$(strip $(MAKE_OUT))' ''
-($error common.mak not included)
+$(error common.mak not included)
 endif
 
 ifeq '$(strip $(TARGET))' ''
-($error TARGET output name not set)
+$(error TARGET output name not set)
 endif
 
 # ---------------------------------------------------------------------------
@@ -146,7 +146,7 @@ $(TARGETOUT): $(ALL_MODULES) $(PICOOS_LIB) $(OBJLIST) $(COMMONDEP) | $(DIR_OUT)
 
 ifneq '$(PORT)' ''
 
-# Set the library as default target.
+# Set the executable as default target.
 all: $(TARGETOUT)
 
 # Target: clean executable.

--- a/ports/avr/port.mak
+++ b/ports/avr/port.mak
@@ -88,7 +88,7 @@ AINCLUDES = .
 # Distinguish between build modes
 ifeq '$(BUILD)' 'DEBUG'
   CFLAGS   += -O0 -g
-  AFLAGS   += -g
+  ASFLAGS  += -g
   CDEFINES += _DBG
   ADEFINES += _DBG
 else

--- a/ports/cortex-m/port.mak
+++ b/ports/cortex-m/port.mak
@@ -103,7 +103,7 @@ AINCLUDES = .
 # Distinguish between build modes
 ifeq '$(BUILD)' 'DEBUG'
   CFLAGS_COMMON   += -g
-  AFLAGS          += -g
+  ASFLAGS         += -g
   CDEFINES        += _DBG
   ADEFINES        += _DBG
 else

--- a/ports/lpc2xxx/port.mak
+++ b/ports/lpc2xxx/port.mak
@@ -99,7 +99,7 @@ AINCLUDES = .
 # Distinguish between build modes
 ifeq '$(BUILD)' 'DEBUG'
   CFLAGS_COMMON   += -g
-  AFLAGS          += -g
+  ASFLAGS         += -g
   CDEFINES        += _DBG
   ADEFINES        += _DBG
 else

--- a/ports/msp430/port.mak
+++ b/ports/msp430/port.mak
@@ -98,7 +98,7 @@ AINCLUDES = .
 # Distinguish between build modes
 ifeq '$(BUILD)' 'DEBUG'
   CFLAGS_COMMON   += -g
-  AFLAGS          += -g
+  ASFLAGS         += -g
   LDFLAGS         += -g
   CDEFINES        += _DBG
   ADEFINES        += _DBG

--- a/ports/mycpu/port.mak
+++ b/ports/mycpu/port.mak
@@ -84,7 +84,7 @@ AINCLUDES = .
 # Distinguish between build modes
 ifeq '$(BUILD)' 'DEBUG'
   CFLAGS   += -g
-  AFLAGS   += -g
+  ASFLAGS  += -g
   CDEFINES += _DBG
   ADEFINES += _DBG
 else

--- a/ports/pic32/port.mak
+++ b/ports/pic32/port.mak
@@ -105,7 +105,7 @@ AINCLUDES = .
 # Distinguish between build modes
 ifeq '$(BUILD)' 'DEBUG'
   CFLAGS_COMMON   += -g
-  AFLAGS          += -g
+  ASFLAGS         += -g
   CDEFINES        += _DBG
   ADEFINES        += _DBG
 else

--- a/ports/ppc440/port.mak
+++ b/ports/ppc440/port.mak
@@ -90,7 +90,7 @@ AINCLUDES = .
 # Distinguish between build modes
 ifeq '$(BUILD)' 'DEBUG'
   CFLAGS   += -O0 -g -Hon=DWARF
-  AFLAGS   += -g
+  ASFLAGS  += -g
   CDEFINES += _DBG
   ADEFINES += _DBG
 else
@@ -161,7 +161,7 @@ AINCLUDES = .
 # Distinguish between build modes
 ifeq '$(BUILD)' 'DEBUG'
   CFLAGS   += -O0 -g
-  AFLAGS   += -g
+  ASFLAGS  += -g
   CDEFINES += _DBG
   ADEFINES += _DBG
 else

--- a/ports/unix/port.mak
+++ b/ports/unix/port.mak
@@ -94,7 +94,7 @@ AINCLUDES = .
 # Distinguish between build modes
 ifeq '$(BUILD)' 'DEBUG'
   CFLAGS_COMMON   += -g
-  AFLAGS          += -g
+  ASFLAGS         += -g
   CDEFINES        += _DBG
   ADEFINES        += _DBG
 else

--- a/ports/x86w32/port.mak
+++ b/ports/x86w32/port.mak
@@ -232,7 +232,7 @@ AINCLUDES = .
 # Distinguish between build modes
 ifeq '$(BUILD)' 'DEBUG'
   CFLAGS   += -O0 -g
-  AFLAGS   += -g
+  ASFLAGS  += -g
   CDEFINES += _DBG
   ADEFINES += _DBG
 else


### PR DESCRIPTION
* Some error messages couldn't be printed.
* Debugging flags weren't passed to assemblers because they were assigned to a variable-name which had a wrong spelling.